### PR TITLE
issue#1 ユーザー削除をリーダーか自身に限定する機能を追加

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,7 +30,7 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif current_user != assign.team.owner && assigned_user != current_user
+    elsif current_user.id != assign.team.owner_id && assigned_user.id != current_user.id
       I18n.t('views.messages.leader_or_mine_destroy')
     elsif assign.destroy
       set_next_team(assign, assigned_user)

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -17,7 +17,6 @@ class AssignsController < ApplicationController
   def destroy
     assign = Assign.find(params[:id])
     destroy_message = assign_destroy(assign, assign.user)
-
     redirect_to team_url(params[:team_id]), notice: destroy_message
   end
 
@@ -31,6 +30,8 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
+    elsif current_user != assign.team.owner && assigned_user != current_user
+      I18n.t('views.messages.leader_or_mine_destroy')
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')
@@ -62,7 +63,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
+  def find_team(*)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    unless @team.owner == current_user
+      redirect_to @team, notice: I18n.t('views.messages.leader_only_edit')
+    end
+  end
 
   def create
     @team = Team.new(team_params)

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,7 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <% if assign.user == current_user || @team.owner == current_user%>
+                      <% if assign.user.id == current_user.id || @team.owner_id == current_user.id %>
                         <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
                       <% end %>
                     </tr>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if assign.user == current_user || @team.owner == current_user%>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -253,6 +253,8 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      leader_only_edit: 'チームリーダーしか編集できません'
+      leader_or_mine_destroy: 'チームリーダー又は自分自身しか削除できません'
     button:
       submit: '投稿'
       edit: '編集'


### PR DESCRIPTION
- [✅ ] Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
- [✅ ] TeamのeditはTeamのリーダー（オーナー）のみができるようにすること

assigns_controller
assign_destroyメソッドの分岐にオーナーか、自身かと言う分岐を追加

teams_controller
editアクションでcurrnt_userがオーナーでなければリダイレクトして戻るという処理に



