### PR TITLE
issues#2 チームリーダーが、他のチームメンバーにリーダー権限を渡せる機能を実装

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -62,7 +62,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
+  def find_team(*)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -50,6 +50,8 @@ class TeamsController < ApplicationController
   def assign_owner
     if @team.owner == current_user
       @team.update(owner_id: params[:owner_id])
+      @user = User.find(@team.owner_id)
+      AssignMailer.assign_owner_email(@user.email).deliver
       redirect_to @team, notice: I18n.t('views.messages.authority_transfer')
     end
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show edit update destroy]
+  before_action :set_team, only: %i[show edit update destroy assign_owner]
 
   def index
     @teams = Team.all
@@ -45,6 +45,13 @@ class TeamsController < ApplicationController
 
   def dashboard
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
+  end
+
+  def assign_owner
+    if @team.owner == current_user
+      @team.update(owner_id: params[:owner_id])
+      redirect_to @team, notice: I18n.t('views.messages.authority_transfer')
+    end
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -48,7 +48,7 @@ class TeamsController < ApplicationController
   end
 
   def assign_owner
-    if @team.owner == current_user
+    if @team.owner_id == current_user.id
       @team.update(owner_id: params[:owner_id])
       @user = User.find(@team.owner_id)
       AssignMailer.assign_owner_email(@user.email).deliver

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -6,4 +6,9 @@ class AssignMailer < ApplicationMailer
     @password = password
     mail to: @email, subject: I18n.t('views.messages.complete_registration')
   end
+
+  def assign_owner_email(email)
+    @email = email
+    mail to: @email, subject: I18n.t('views.messages.authority_transfer_complete')
+  end
 end

--- a/app/views/assign_mailer/assign_owner_email.html.erb
+++ b/app/views/assign_mailer/assign_owner_email.html.erb
@@ -1,0 +1,3 @@
+<h1><%= I18n.t('views.messages.authority_transfer_complete') %></h1>
+
+<h4>これからリーダーです。頑張りましょう！</h4>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,6 +42,9 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if @team.owner == current_user && assign.user != @team.owner %>
+                        <td><%= link_to I18n.t('views.button.transfer'), assign_owner_team_path(owner_id: assign.user_id), method: :post, class: 'btn btn-sm btn-info' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,7 +42,7 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
-                      <% if @team.owner == current_user && assign.user != @team.owner %>
+                      <% if @team.owner_id == current_user.id && assign.user.id != @team.owner_id %>
                         <td><%= link_to I18n.t('views.button.transfer'), assign_owner_team_path(owner_id: assign.user_id), method: :post, class: 'btn btn-sm btn-info' %></td>
                       <% end %>
                     </tr>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -254,6 +254,7 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
       authority_transfer: '権限を移動しました'
+      authority_transfer_complete: 'リーダー権限を移動しました。あなたがリーダーです'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -253,12 +253,14 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      authority_transfer: '権限を移動しました'
     button:
       submit: '投稿'
       edit: '編集'
       delete: '削除'
       create: '作成'
       invite: '招待'
+      transfer: '権限移動'
     top:
       line1: 'このアプリケーションは、チームごと、議題ごとに別れて'
       line2: '特定のイシュー（議題）をメンバーで見やすく共有するためのアプリケーションです'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,13 +8,16 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles do
         resources :comments
       end
+    end
+    member do
+      post :assign_owner
     end
   end
 


### PR DESCRIPTION
- [✅ ] そのTeamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現する。そのボタンを押すと、そのTeamのオーナーが選択したUserに変更される

- [ ✅] Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ
情報処理が完了した後はそのTeamのshowに飛ぶ（つまり同じ場所にredirectする）
その他、アプリケーションの挙動に不審な点やエラーがないこと

- teams_controllerにassign_ownerメソッドを実装
- routesにassign_ownerをpostで追加
- show.htmlにリーダーのみ他ユーザーに権限移動用のボタンを表示
- assign_mailer.rbにassign_owner_emailメソッドを追加