### PR TITLE
Issue#3 アジェンダの削除機能を実装、アジェンダに参加しているメンバにメール送信機能実装

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -15,9 +15,17 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
+    end
+  end
+
+  def destroy
+    set_agenda
+    if current_user.id == @agenda.user.id || current_user.id == @agenda.team.owner_id
+      @agenda.destroy
+      redirect_to dashboard_url
     end
   end
 

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -24,7 +24,11 @@ class AgendasController < ApplicationController
   def destroy
     set_agenda
     if current_user.id == @agenda.user.id || current_user.id == @agenda.team.owner_id
+      @members = @agenda.team.members
       @agenda.destroy
+      @members.each do |member|
+        AssignMailer.agenda_destroy_mail(member.email).deliver
+      end
       redirect_to dashboard_url
     end
   end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -62,7 +62,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
+  def find_team(*)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -6,4 +6,9 @@ class AssignMailer < ApplicationMailer
     @password = password
     mail to: @email, subject: I18n.t('views.messages.complete_registration')
   end
+
+  def agenda_destroy_mail(email)
+    @email = email
+    mail to: @email, subject: I18n.t('views.messages.agenda_delete')
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,7 +3,7 @@ class Article < ApplicationRecord
   validates :content, presence: true, length: { minimum: 1, maximum: 1000 }
   belongs_to :user
   belongs_to :team
-  belongs_to :agenda
+  belongs_to :agenda, dependent: :destroy
   has_many :comments, dependent: :destroy
   mount_uploader :image, ImageUploader
 end

--- a/app/views/assign_mailer/agenda_destroy_mail.html.erb
+++ b/app/views/assign_mailer/agenda_destroy_mail.html.erb
@@ -1,0 +1,3 @@
+<h1><%= I18n.t('views.messages.agenda_delete') %></h1>
+
+<h4>アジェンダが削除されましたので通知です。</h4>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,6 +37,9 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+            <% if agenda.user.id == current_user.id || agenda.team.owner_id == current_user.id %>
+              <%= link_to I18n.t('views.button.delete'), agenda_path(agenda.id), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+            <% end %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -253,6 +253,7 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      agenda_delete: 'アジェンダが削除されました'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do


### PR DESCRIPTION
- [✅] Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
- [✅] Agendaに紐づいているarticleも一緒に削除される。Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
- [✅] Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ。情報処理が完了した後はDashBoardに飛ぶ。

- agenda_controllerにdestroy メソッドを追加。
- show.htmlにAgendaの作者とteamのリーダーのみ削除ボタンを表示するように変更。
- assign_mailer.rbにagenda_destroy_mailメソッドを追加し、コントローラーによりagenda削除時に紐づくメンバーにメール送信する機能を追加
